### PR TITLE
allow both relative/absolute paths for Frontend apps

### DIFF
--- a/dist/browser/kuroshiro.js
+++ b/dist/browser/kuroshiro.js
@@ -1398,7 +1398,14 @@ BrowserDictionaryLoader.prototype = Object.create(DictionaryLoader.prototype);
  */
 BrowserDictionaryLoader.prototype.loadArrayBuffer = function (url, callback) {
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", url, true);
+    var dir_path = '';
+    var uri = location.pathname.substr(1);
+    if (uri) {
+      var dir = uri.split('/').length;
+      for (var i = 1; i != dir; ++i) dir_path += '../'
+    }
+
+    xhr.open("GET", dir_path + url, true);
     xhr.responseType = "arraybuffer";
     xhr.onload = function () {
         if (this.status !== 200) {


### PR DESCRIPTION

Before

```
If loaded on base url
<script src='/bower_components/kuroshiro/dist/browser/kuroshiro.js'></script>
www.example.com   kuroshiro.init(callback) /works
```

```
If NOT loaded on base but loaded on a relative
<script src='/bower_components/kuroshiro/dist/browser/kuroshiro.js'></script>
www.example.com/mydemo/   kuroshiro.init(callback) //does not work
```


After this Pull

Both relative and absolute will work

Please consider this fix