### PR TITLE
Make .init() callback optional

### DIFF
--- a/src/kuroshiro.js
+++ b/src/kuroshiro.js
@@ -330,7 +330,7 @@ var init = function(options, callback){
 
         tokenizer = newtokenizer;
         kuroshiro.tokenize = tokenizer.tokenize;
-        callback();
+        if(callback) callback();
     });
 };
 


### PR DESCRIPTION
I want to simply init the object without a callback.

For your reference, here is my particular usage scenario right now - where I specify an empty function to avoid an error:
```javascript
const kanji2kana = require('kuroshiro')
kanji2kana.init(function(){})

router.post('/kanji2kana', (req, res) => {
    const converted= kanji2kana.convert(req.body.text)
    res.status(200).send(converted)
})
```
I want to just do `.init()`, with no callback needed.
よろしくお願いします