### PR TITLE
Fix it would replace from first 'src' when getting full path of 'kuromoji/dict'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - 8.9
 
 before_install:
   - npm install -g gulp

--- a/dist/node/kuroshiro.js
+++ b/dist/node/kuroshiro.js
@@ -369,7 +369,7 @@ var init = function(options, callback){
 
     var dicPath = options.dicPath;
     if(!dicPath){
-        if(isNode) dicPath = require.resolve('kuromoji').replace(/src.*/,'dict/');
+        if(isNode) dicPath = require.resolve('kuromoji').replace(/src(?!.*src).*/,'dict/');
         else dicPath = 'bower_components/kuroshiro/dist/dict/';
     }
     kuromoji.builder({ dicPath: dicPath }).build(function (err, newtokenizer) {


### PR DESCRIPTION
If there are multiple 'src' in the full path of 'kuromoji', it would replace from first 'src'.

like this
https://regex101.com/r/zsP8O3/3

fixed
https://regex101.com/r/zsP8O3/2